### PR TITLE
Update grails-app/controllers/org/grails/paypal/PaypalController.groovy

### DIFF
--- a/grails-app/controllers/org/grails/paypal/PaypalController.groovy
+++ b/grails-app/controllers/org/grails/paypal/PaypalController.groovy
@@ -4,7 +4,7 @@ class PaypalController {
 
 	static allowedMethods = [buy: 'POST', notify: 'POST']
 
-	def notify = {
+	def notifyPaypal = {
 		log.debug "Received IPN notification from PayPal Server ${params}"
 		def config = grailsApplication.config.grails.paypal
 		def server = config.server


### PR DESCRIPTION
The closure notify in PaypalController overrides the Object.notify method, if you are working with Grails 2.0.0.
