### PR TITLE
Turning off hibernate mapping auto-import

### DIFF
--- a/grails-app/domain/org/grails/paypal/Payment.groovy
+++ b/grails-app/domain/org/grails/paypal/Payment.groovy
@@ -1,6 +1,9 @@
 package org.grails.paypal
 
 class Payment implements Serializable {
+        static mapping = {
+                autoImport false
+        }
 	static final PENDING = 'PENDING'
 	static final INVALID = 'INVALID'
 	static final FAILED = 'FAILED'


### PR DESCRIPTION
Payment is a very generic domain name, which would easily conflict with many project's existing structure (it did with mine). Explicitly requiring references to use the full package and class would make for more deliberate code and alleviate the aforementioned conflict.
